### PR TITLE
Add release workflow to dispatch downstream image builds

### DIFF
--- a/.github/workflows/notify-docker-image-repo.yml
+++ b/.github/workflows/notify-docker-image-repo.yml
@@ -1,0 +1,56 @@
+name: Notify downstream image build
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+jobs:
+  dispatch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send repository_dispatch to downstream repo
+        env:
+          TARGET_OWNER: ikidd
+          TARGET_REPO: file-hunter-dockerized
+          TOKEN: ${{ secrets.DOWNSTREAM_REPO_TOKEN }}
+          TAG: ${{ github.event.release.tag_name }}
+          RELEASE_URL: ${{ github.event.release.html_url }}
+          PUBLISHED_AT: ${{ github.event.release.published_at }}
+          RELEASE_TARGET: ${{ github.event.release.target_commitish }}
+        run: |
+          set -euo pipefail
+
+          if [ -z "${TOKEN}" ]; then
+            echo "DOWNSTREAM_REPO_TOKEN is not configured."
+            exit 1
+          fi
+
+          SHA="$(git ls-remote "https://github.com/${GITHUB_REPOSITORY}.git" "refs/tags/${TAG}^{}" | awk '{print $1}')"
+          if [ -z "${SHA}" ]; then
+            SHA="$(git ls-remote "https://github.com/${GITHUB_REPOSITORY}.git" "refs/tags/${TAG}" | awk '{print $1}')"
+          fi
+          if [ -z "${SHA}" ]; then
+            echo "Failed to resolve tag ${TAG} to a commit SHA."
+            exit 1
+          fi
+
+          curl -sSf -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${TOKEN}" \
+            "https://api.github.com/repos/${TARGET_OWNER}/${TARGET_REPO}/dispatches" \
+            -d @- <<JSON
+          {
+            "event_type": "upstream_release",
+            "client_payload": {
+              "tag": "${TAG}",
+              "sha": "${SHA}",
+              "release_url": "${RELEASE_URL}",
+              "published_at": "${PUBLISHED_AT}",
+              "source_repo": "${GITHUB_REPOSITORY}",
+              "target_commitish": "${RELEASE_TARGET}"
+            }
+          }
+          JSON


### PR DESCRIPTION
Trigger a repository_dispatch event to ikidd/file-hunter-dockerized whenever a release is published, including resolved tag SHA and release metadata for downstream build automation.

I've created a finegrain token I will have to get to you to add to your repo, as an Actions secret:

It will be added at:

Settings -> Secrets and variables -> Actions
Click New repository secret
Name: DOWNSTREAM_REPO_TOKEN
Value: the PAT / fine-grained token I will get you.
Save

If you don't add this PR, the docker image will still build but it will wait until the next scheduled run.  This PR causes a trigger on a successful release creation in your repo.

If you want to go ahead with this PR, DM me for the token.